### PR TITLE
Validate block headers without proof validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-name: CI on Push
+name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   ci:

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -109,6 +109,12 @@ impl<'a, T: ChainStore> Chain<T> {
             ));
         }
 
+        // todo: check proof
+        // get current aggregated public key from latest federation block and verify the proof
+        // using the pubkey.
+        // After federation management implemented in Tapyrus Core, it is needed to search current
+        // aggregated public key in chain. So, checking proof logic should be in here.
+
         // check prev_blockhash
         if tip.header.bitcoin_hash() != header.prev_blockhash {
             return Err(Error::BlockValidationError(

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -28,7 +28,10 @@ pub enum Error {
 pub enum BlockValidationErrorCause {
     /// The block can't connect current chain tip.
     CantConnectToTip,
-    WrongBlockVersion { wrong_version: u32, correct_version: u32 }
+    WrongBlockVersion {
+        wrong_version: u32,
+        correct_version: u32,
+    },
 }
 
 impl From<tapyrus::consensus::encode::Error> for Error {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -32,6 +32,8 @@ pub enum BlockValidationErrorCause {
         wrong_version: u32,
         correct_version: u32,
     },
+    BlockTimeTooOld,
+    BlockTimeTooNew,
 }
 
 impl From<tapyrus::consensus::encode::Error> for Error {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -28,6 +28,7 @@ pub enum Error {
 pub enum BlockValidationErrorCause {
     /// The block can't connect current chain tip.
     CantConnectToTip,
+    WrongBlockVersion { wrong_version: u32, correct_version: u32 }
 }
 
 impl From<tapyrus::consensus::encode::Error> for Error {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -19,6 +19,15 @@ pub use chain::ChainStore;
 pub enum Error {
     EncodeError(tapyrus::consensus::encode::Error),
     BitcoinHashesError(bitcoin_hashes::Error),
+    /// The error which arises under validating blocks.
+    BlockValidationError(BlockValidationErrorCause),
+}
+
+/// Causes of BlockValidationError
+#[derive(Debug)]
+pub enum BlockValidationErrorCause {
+    /// The block can't connect current chain tip.
+    CantConnectToTip,
 }
 
 impl From<tapyrus::consensus::encode::Error> for Error {

--- a/src/network/block_header_download.rs
+++ b/src/network/block_header_download.rs
@@ -74,7 +74,9 @@ where
     }
 
     for header in headers {
-        let _ = chain_active.connect_block_header(header);
+        if let Err(e) = chain_active.connect_block_header(header) {
+            return Err(Error::ChainError(e));
+        }
     }
 
     if !all_headers_downloaded {

--- a/src/network/block_header_download.rs
+++ b/src/network/block_header_download.rs
@@ -5,11 +5,12 @@
 use crate::chain::{Chain, ChainStore};
 use crate::network::{error::MaliciousPeerCause, Error, Peer};
 use crate::ChainState;
+use bitcoin_hashes::sha256d;
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 use tapyrus::network::message::NetworkMessage;
 use tapyrus::network::message::RawNetworkMessage;
-use tapyrus::BlockHeader;
+use tapyrus::{BitcoinHash, BlockHeader};
 use tokio::prelude::{Async, Future, Sink, Stream};
 
 /// The maximum number of block headers that can be in a single headers message.
@@ -60,6 +61,17 @@ where
     }
 
     let all_headers_downloaded = headers.len() < max_headers_results;
+
+    // Check whether headers sequence is continuous.
+    let mut header_iter = (&headers).into_iter().peekable();
+    while let (Some(header), Some(next_header)) = (header_iter.next(), header_iter.peek()) {
+        if header.bitcoin_hash() != next_header.prev_blockhash {
+            return Err(Error::MaliciousPeer(
+                peer.id,
+                MaliciousPeerCause::SendNonContinuousHeadersSequence,
+            ));
+        }
+    }
 
     for header in headers {
         let _ = chain_active.connect_block_header(header);
@@ -145,7 +157,29 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(Error::MaliciousPeer(peer_id, _)) => assert_eq!(peer_id, 0),
+            Err(Error::MaliciousPeer(peer_id, MaliciousPeerCause::SendOverMaxHeadersResults)) => {
+                assert_eq!(peer_id, 0);
+            }
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_process_headers_fails_when_passed_unchained_headers() {
+        let (_here, there) = channel::<RawNetworkMessage>();
+        let mut peer = Peer::new(0, there, "0.0.0.0:0".parse().unwrap(), Network::Regtest);
+
+        let mut chain_state = ChainState::new(get_chain());
+        let mut chain_active = chain_state.borrow_mut_chain_active();
+        let mut headers = get_test_headers(1, 11);
+        headers.reverse(); // reverse block headers order, so the headers
+        let result = process_headers(&mut peer, &mut chain_active, headers, 10);
+
+        assert!(result.is_err());
+        match result {
+            Err(Error::MaliciousPeer(peer_id, MaliciousPeerCause::SendOverMaxHeadersResults)) => {
+                assert_eq!(peer_id, 0);
+            }
             _ => assert!(false),
         }
     }
@@ -230,7 +264,7 @@ mod tests {
 
                 let headers_message = RawNetworkMessage {
                     magic: Network::Regtest.magic(),
-                    payload: NetworkMessage::Headers(get_test_headers(10, 10)),
+                    payload: NetworkMessage::Headers(get_test_headers(11, 10)),
                 };
 
                 let _ = here.start_send(headers_message);
@@ -257,7 +291,7 @@ mod tests {
 
                 let headers_message = RawNetworkMessage {
                     magic: Network::Regtest.magic(),
-                    payload: NetworkMessage::Headers(get_test_headers(20, 3)),
+                    payload: NetworkMessage::Headers(get_test_headers(21, 3)),
                 };
 
                 let _ = here.start_send(headers_message);

--- a/src/network/error.rs
+++ b/src/network/error.rs
@@ -20,6 +20,8 @@ pub enum MaliciousPeerCause {
     /// The peer send over maximum number which is MAX_HEADERS_RESULTS of headers in single
     /// headers message.
     SendOverMaxHeadersResults,
+    /// The peer send non-continuous headers sequence.
+    SendNonContinuousHeadersSequence,
 }
 
 impl From<std::io::Error> for Error {

--- a/src/network/error.rs
+++ b/src/network/error.rs
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+use crate::chain;
 use crate::network::peer::PeerID;
 use crate::network::utils::codec;
 
@@ -12,6 +13,7 @@ pub enum Error {
     UnboundedSendError(tokio::sync::mpsc::error::UnboundedSendError),
     UnboundedRecvError(tokio::sync::mpsc::error::UnboundedRecvError),
     MaliciousPeer(PeerID, MaliciousPeerCause),
+    ChainError(chain::Error),
     WrongMagicBytes,
 }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -22,3 +22,5 @@ pub mod utils;
 mod error;
 pub use self::error::Error;
 pub use self::error::MaliciousPeerCause;
+
+pub mod time;

--- a/src/network/time.rs
+++ b/src/network/time.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 Chaintope Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+use core::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::SystemTime;
+
+static MOCK_TIME: AtomicU64 = AtomicU64::new(0);
+
+/// returns adjusted time with other nodes.
+/// TODO: Implement actual logic refer to https://github.com/chaintope/tapyrus-core/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/timedata.cpp#L35
+pub fn get_adjusted_time() -> u64 {
+    now()
+}
+
+/// returns current unix time
+pub fn now() -> u64 {
+    let mock = MOCK_TIME.load(Ordering::Relaxed);
+    if mock != 0 {
+        return mock;
+    }
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(now > 0);
+    now
+}
+
+pub fn set_mock_time(mock_time_in: u64) {
+    MOCK_TIME.store(mock_time_in, Ordering::Relaxed);
+}
+
+pub fn get_mock_time() -> u64 {
+    MOCK_TIME.load(Ordering::Relaxed)
+}

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -169,6 +169,20 @@ pub fn get_chain() -> Chain<OnMemoryChainStore> {
     Chain::new(store)
 }
 
+pub fn get_test_chain(height: usize) -> Chain<OnMemoryChainStore> {
+    let mut chain = get_chain();
+
+    if height == 0 {
+        return chain;
+    }
+
+    for header in get_test_headers(1, height) {
+        chain.connect_block_header(header).unwrap();
+    }
+
+    chain
+}
+
 pub struct TwoWayChannel<T> {
     sender: UnboundedSender<T>,
     receiver: UnboundedReceiver<T>,


### PR DESCRIPTION
Regarding proof validation is going to be implement after rust-tapyrus adapt new block header structure which is including aggregated pubkey in block header.

In this pull request changes include following check.

* checking header sequence when received HEADERS message
* checking previous block hash
* checking block version
* checking block timestamp